### PR TITLE
use `pkgs.lib` instead of `stdenv.lib`

### DIFF
--- a/dub2nix.nix
+++ b/dub2nix.nix
@@ -9,7 +9,7 @@ mkDubDerivation {
     version = "0.2.4";
     # doCheck = true;
     propagatedBuildInputs = [ pkgs.nix-prefetch-git pkgs.cacert ];
-    meta = with pkgs.stdenv.lib; {
+    meta = with pkgs.lib; {
        homepage = "https://github.com/lionello/dub2nix";
        maintainers = [ maintainers.lionello ];
        license = licenses.mit;

--- a/mkDub.nix
+++ b/mkDub.nix
@@ -1,5 +1,6 @@
 { pkgs ? import <nixpkgs> {},
   stdenv ? pkgs.stdenv,
+  lib ? pkgs.lib,
   rdmd ? pkgs.rdmd,
   dmd ? pkgs.dmd,
   dub ? pkgs.dub }:


### PR DESCRIPTION
See NixOS/nixpkgs#108938

`stdenv.lib` is no longer present in Nixpkgs master. `pkgs.lib` can be used instead.