### PR TITLE
Bump vibe.d version

### DIFF
--- a/dub.selections.json
+++ b/dub.selections.json
@@ -2,6 +2,6 @@
 	"fileVersion": 1,
 	"versions": {
 		"stdx-allocator": "2.77.5",
-		"vibe-d": "0.8.5"
+		"vibe-d": "0.9.4"
 	}
 }

--- a/dub.selections.nix
+++ b/dub.selections.nix
@@ -3,13 +3,13 @@
   fetch = {
     type = "git";
     url = "https://github.com/vibe-d/vibe.d.git";
-    rev = "v0.8.5";
-    sha256 = "0s1caxqmq2497j5x8h06f44nr597h9zac8qxxml953lkaqkhbzgy";
+    rev = "v0.9.4";
+    sha256 = "0kjnrlz30gvb08v79d7x5laapk13fxyj1cfr31wx0px3xrnjpzfq";
     fetchSubmodules = false;
-    date = "2019-03-24T14:45:15+01:00";
+    date = "2021-09-30T14:24:53+02:00";
     deepClone = false;
     leaveDotGit = false;
-    path = "/nix/store/kz5g44dncvznlkm38a74cmm4qyl9nr6b-vibe.d";
+    path = "/nix/store/3x9z474xs6d65w1my3s7kbr45z938rnc-vibe.d";
   };
 } {
   fetch = {


### PR DESCRIPTION
The version of vibe.d currently pinned in dub2nix does not seem to build with the latest version of dmd. This seems to be due to 2.097 removing `std.exception.enforceEx`. 

This patch bumps vibe.d to a newer version where that issue is fixed. As far as I can tell, this doesn't affect dub2nix functionality. 